### PR TITLE
Null safety for autovalidateMode

### DIFF
--- a/lib/checkbox_icon_formfield.dart
+++ b/lib/checkbox_icon_formfield.dart
@@ -7,7 +7,7 @@ class CheckboxIconFormField extends FormField<bool> {
     BuildContext? context,
     FormFieldSetter<bool>? onSaved,
     bool initialValue = false,
-    AutovalidateMode autovalidateMode,
+    AutovalidateMode? autovalidateMode,
     bool enabled = true,
     IconData trueIcon = Icons.check,
     IconData falseIcon = Icons.check_box_outline_blank,

--- a/lib/checkbox_list_tile_formfield.dart
+++ b/lib/checkbox_list_tile_formfield.dart
@@ -9,7 +9,7 @@ class CheckboxListTileFormField extends FormField<bool> {
     FormFieldSetter<bool>? onSaved,
     FormFieldValidator<bool>? validator,
     bool initialValue = false,
-    AutovalidateMode autovalidateMode,
+    AutovalidateMode? autovalidateMode,
     bool enabled = true,
     bool dense = false,
     Color? errorColor,


### PR DESCRIPTION
Hey @reidha thanks for merging my PRs!
The migration of `autovalidateMode` was missing in my PR, because it wasn't present #3 as I added it in #4. Without this PR is the lib not usable.
Would you mind adding "hacktoberfest" as topic?